### PR TITLE
updates to input_nml_file specification for FMS enhancements

### DIFF
--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -533,6 +533,8 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
    Init_parm%hydrostatic     = Atm(mygrid)%flagstruct%hydrostatic
 
 #ifdef INTERNAL_FILE_NML
+   allocate(Init_parm%input_nml_file, mold=input_nml_file)  ! needed for a suspected bug in gnu
+                                                            ! https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100886
    Init_parm%input_nml_file  => input_nml_file
    Init_parm%fn_nml='using internal file'
 #else

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -145,8 +145,8 @@ module GFS_typedefs
     character(len=32), pointer :: tracer_names(:) !< tracers names to dereference tracer id
                                                   !< based on name location in array
     character(len=64) :: fn_nml                   !< namelist filename
-    character(len=256), pointer :: input_nml_file(:) !< character string containing full namelist
-                                                     !< for use with internal file reads
+    character(len=:), pointer, dimension(:) :: input_nml_file => null() !< character string containing full namelist
+                                                                        !< for use with internal file reads
   end type GFS_init_type
 
 
@@ -547,8 +547,8 @@ module GFS_typedefs
     integer              :: nthreads        !< OpenMP threads available for physics
     integer              :: nlunit          !< unit for namelist
     character(len=64)    :: fn_nml          !< namelist filename for surface data cycling
-    character(len=256), pointer :: input_nml_file(:) !< character string containing full namelist
-                                                     !< for use with internal file reads
+    character(len=:), pointer, dimension(:) :: input_nml_file => null() !< character string containing full namelist
+                                                                        !< for use with internal file reads
     integer              :: input_nml_file_length    !< length (number of lines) in namelist for internal reads
     integer              :: logunit
     real(kind=kind_phys) :: fhzero          !< hours between clearing of diagnostic buckets
@@ -2942,7 +2942,7 @@ module GFS_typedefs
     integer,                intent(in) :: idat(8)
     integer,                intent(in) :: jdat(8)
     character(len=32),      intent(in) :: tracer_names(:)
-    character(len=256),     intent(in), pointer :: input_nml_file(:)
+    character(len=:),       intent(in), pointer, dimension(:) :: input_nml_file
     integer,                intent(in) :: blksz(:)
     real(kind=kind_phys), dimension(:), intent(in) :: ak
     real(kind=kind_phys), dimension(:), intent(in) :: bk
@@ -3537,6 +3537,8 @@ module GFS_typedefs
 
 !--- read in the namelist
 #ifdef INTERNAL_FILE_NML
+    allocate(Model%input_nml_file, mold=input_nml_file)  ! needed for a suspected bug in gnu
+                                                         ! https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100886
     Model%input_nml_file => input_nml_file
     read(Model%input_nml_file, nml=gfs_physics_nml)
     ! Set length (number of lines) in namelist for internal reads

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -2300,7 +2300,7 @@
   units = none
   dimensions = (number_of_lines_of_namelist_filename_for_internal_file_reads)
   type = character
-  kind = len=256
+  kind = len=:
 [logunit]
   standard_name = iounit_log
   long_name = fortran unit number for logfile


### PR DESCRIPTION
## Description
Updates to input_nml_file definitions in physics typedefs to be in sync with FMS enhancements.  There are additional statements added (allocates) to workaround a suspected gnu bug (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100886)

I believe the update in the metadata file is correct, but I'm not 100% sure on that one.

### Issue(s) addressed
Inability to use the latest 2021.02 release from FMS.



## Testing
They have been previously tested in the UFS RTS.


## Dependencies
N/A
